### PR TITLE
Add template assets for Kyverno policy and reports

### DIFF
--- a/kubernetes/blueprints/kyverno-blueprints.json
+++ b/kubernetes/blueprints/kyverno-blueprints.json
@@ -1,0 +1,452 @@
+[
+    {
+      "identifier": "cluster",
+      "description": "This blueprint represents a Kubernetes Cluster",
+      "title": "Cluster",
+      "icon": "Cluster",
+      "schema": {
+        "properties": {},
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {}
+    },
+    {
+      "identifier": "namespace",
+      "description": "This blueprint represents a k8s Namespace",
+      "title": "Namespace",
+      "icon": "Environment",
+      "schema": {
+        "properties": {
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Namespace was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Namespace"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "Cluster": {
+          "title": "Cluster",
+          "description": "The namespace's Kubernetes cluster",
+          "target": "cluster",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "node",
+      "description": "This blueprint represents a k8s Node",
+      "title": "Node",
+      "icon": "Node",
+      "schema": {
+        "properties": {
+          "creationTimestamp": {
+            "type": "string",
+            "icon": "DeployedAt",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Node was created (added to the cluster)"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Node"
+          },
+          "ready": {
+            "type": "string",
+            "title": "Node Readiness",
+            "description": "Node ready status",
+            "enum": [
+              "True",
+              "False"
+            ],
+            "enumColors": {
+              "False": "red",
+              "True": "green"
+            }
+          },
+          "totalMemory": {
+            "type": "string",
+            "icon": "GPU",
+            "title": "Total Memory (kibibytes)",
+            "description": "Total memory capacity of the Node"
+          },
+          "kubeletVersion": {
+            "type": "string",
+            "title": "Kubelet Version",
+            "description": "The node's kubelet version"
+          },
+          "totalCPU": {
+            "type": "string",
+            "icon": "CPU",
+            "title": "Total CPU (milli-cores)",
+            "description": "Total CPU capacity of the Node"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "Cluster": {
+          "title": "Cluster",
+          "target": "cluster",
+          "required": false,
+          "many": true
+        }
+      }
+    },
+    {
+      "identifier": "workload",
+      "description": "This blueprint represents a k8s Workload. This includes all k8s objects which can create pods (deployments[replicasets], daemonsets, statefulsets...)",
+      "title": "Workload",
+      "icon": "Deployment",
+      "schema": {
+        "properties": {
+          "availableReplicas": {
+            "type": "number",
+            "title": "Running Replicas",
+            "description": "Current running replica count"
+          },
+          "containers": {
+            "type": "array",
+            "title": "Containers",
+            "default": [],
+            "description": "The containers for each pod instance of the Workload"
+          },
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Workload was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Workload"
+          },
+          "replicas": {
+            "type": "number",
+            "title": "Wanted Replicas",
+            "description": "Wanted replica count"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "description": "Rollout Strategy"
+          },
+          "hasPrivileged": {
+            "type": "boolean",
+            "title": "Has Privileged Container"
+          },
+          "hasLatest": {
+            "type": "boolean",
+            "title": "Has 'latest' tag",
+            "description": "Has Container with 'latest' as image tag"
+          },
+          "hasLimits": {
+            "type": "boolean",
+            "title": "All containers have limits"
+          },
+          "isHealthy": {
+            "type": "string",
+            "enum": [
+              "Healthy",
+              "Unhealthy"
+            ],
+            "enumColors": {
+              "Healthy": "green",
+              "Unhealthy": "red"
+            },
+            "title": "Workload Health"
+          },
+          "kind": {
+            "title": "Workload Kind",
+            "description": "The kind of Workload",
+            "type": "string",
+            "enum": [
+              "StatefulSet",
+              "DaemonSet",
+              "Deployment",
+              "Rollout"
+            ]
+          },
+          "strategyConfig": {
+            "type": "object",
+            "title": "Strategy Config",
+            "description": "The workloads rollout strategy"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "namespace": {
+          "title": "Namespace",
+          "target": "namespace",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "replicaSet",
+      "description": "This blueprint represents a k8s ReplicaSet",
+      "title": "ReplicaSet",
+      "icon": "Deployment",
+      "schema": {
+        "properties": {
+          "replicaSetJson": {
+            "title": "ReplicaSet Json",
+            "type": "object",
+            "description": "The ReplicaSet json"
+          },
+          "availableReplicas": {
+            "type": "number",
+            "title": "Running Replicas",
+            "description": "Current running replica count"
+          },
+          "containers": {
+            "type": "array",
+            "title": "Containers",
+            "default": [],
+            "description": "The containers for each pod instance of the Workload"
+          },
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Workload was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Workload"
+          },
+          "replicas": {
+            "type": "number",
+            "title": "Wanted Replicas",
+            "description": "Wanted replica count"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "description": "Rollout Strategy"
+          },
+          "hasPrivileged": {
+            "type": "boolean",
+            "title": "Has Privileged Container"
+          },
+          "hasLatest": {
+            "type": "boolean",
+            "title": "Has 'latest' tag",
+            "description": "Has Container with 'latest' as image tag"
+          },
+          "hasLimits": {
+            "type": "boolean",
+            "title": "All containers have limits"
+          },
+          "isHealthy": {
+            "type": "string",
+            "enum": [
+              "Healthy",
+              "Unhealthy"
+            ],
+            "enumColors": {
+              "Healthy": "green",
+              "Unhealthy": "red"
+            },
+            "title": "ReplicaSet Health"
+          },
+          "strategyConfig": {
+            "type": "object",
+            "title": "Strategy Config",
+            "description": "The ReplicaSet rollout strategy"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "replicaSetManager": {
+          "title": "Manager",
+          "target": "workload",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "pod",
+      "description": "This blueprint represents a k8s Pod",
+      "title": "Pod",
+      "icon": "Service",
+      "schema": {
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "title": "Conditions",
+            "default": [],
+            "description": "Pod's conditions"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Pod"
+          },
+          "phase": {
+            "type": "string",
+            "title": "Pod phase",
+            "description": "Pod's running phase"
+          },
+          "startTime": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "Pod's creation date"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {
+        "containers": {
+          "title": "Containers",
+          "path": "workload.containers"
+        }
+      },
+      "calculationProperties": {},
+      "relations": {
+        "Node": {
+          "title": "Node",
+          "description": "The node the pod is running on",
+          "target": "node",
+          "required": false,
+          "many": false
+        },
+        "workload": {
+          "title": "Workload",
+          "description": "The workload responsible for the pod",
+          "target": "workload",
+          "required": false,
+          "many": false
+        },
+        "replicaSet": {
+          "title": "ReplicaSet",
+          "description": "The ReplicaSet managing the pod (if it exists)",
+          "target": "replicaSet",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+        "identifier": "kyvernoPolicy",
+        "title": "Kyverno Policy",
+        "icon": "Cluster",
+        "schema": {
+          "properties": {
+            "admission": {
+              "title": "Admission",
+              "type": "boolean",
+              "icon": "DefaultProperty"
+            },
+            "background": {
+              "title": "Background",
+              "type": "boolean",
+              "icon": "DefaultProperty"
+            },
+            "createdAt": {
+              "title": "Created At",
+              "type": "string",
+              "format": "date-time",
+              "icon": "DefaultProperty"
+            },
+            "validationFailureAction": {
+              "icon": "DefaultProperty",
+              "title": "Validation Failure Action",
+              "type": "string",
+              "enum": [
+                "Audit",
+                "Enforce"
+              ],
+              "enumColors": {
+                "Audit": "lightGray",
+                "Enforce": "lightGray"
+              }
+            }
+          },
+          "required": []
+        },
+        "mirrorProperties": {},
+        "calculationProperties": {},
+        "aggregationProperties": {},
+        "relations": {
+          "namespace": {
+            "title": "Namespace",
+            "target": "namespace",
+            "required": false,
+            "many": false
+          }
+        }
+      },
+      {
+        "identifier": "kyvernoPolicyReport",
+        "title": "Kyverno Policy Report",
+        "icon": "Cluster",
+        "schema": {
+          "properties": {
+            "createdAt": {
+              "title": "Created At",
+              "type": "string",
+              "format": "date-time"
+            },
+            "pass": {
+              "title": "Pass",
+              "type": "number"
+            },
+            "fail": {
+              "title": "Fail",
+              "type": "number"
+            },
+            "warn": {
+              "title": "Warn",
+              "type": "number"
+            },
+            "error": {
+              "title": "Error",
+              "type": "number"
+            },
+            "skip": {
+              "title": "Skip",
+              "type": "number"
+            }
+          },
+          "required": []
+        },
+        "mirrorProperties": {},
+        "calculationProperties": {},
+        "aggregationProperties": {},
+        "relations": {
+          "namespace": {
+            "title": "Namespace",
+            "target": "namespace",
+            "required": false,
+            "many": false
+          }
+        }
+      }
+  ]

--- a/kubernetes/kyverno_config.tmpl
+++ b/kubernetes/kyverno_config.tmpl
@@ -1,0 +1,63 @@
+  - kind: kyverno.io/v1/policies
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Cluster"'
+            blueprint: '"kyvernoPolicy"'
+            properties:
+              admission: .spec.admission
+              background: .spec.background
+              validationFailureAction: .spec.validationFailureAction
+              createdAt: .metadata.creationTimestamp
+            relations:
+              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+  
+  - kind: kyverno.io/v1/clusterpolicies
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Cluster"'
+            blueprint: '"kyvernoPolicy"'
+            properties:
+              admission: .spec.admission
+              background: .spec.background
+              validationFailureAction: .spec.validationFailureAction
+              createdAt: .metadata.creationTimestamp
+
+  - kind: wgpolicyk8s.io/v1alpha2/policyreports
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .scope.name
+            icon: '"Cluster"'
+            blueprint: '"kyvernoPolicyReport"'
+            properties:
+              pass: .summary.pass
+              fail: .summary.fail
+              warn: .summary.warn
+              error: .summary.error
+              skip: .summary.skip
+              createdAt: .metadata.creationTimestamp
+            relations:
+              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+
+  - kind: wgpolicyk8s.io/v1alpha2/clusterpolicyreports
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + env.CLUSTER_NAME
+            title: .scope.name
+            icon: '"Cluster"'
+            blueprint: '"kyvernoPolicyReport"'
+            properties:
+              pass: .summary.pass
+              fail: .summary.fail
+              warn: .summary.warn
+              error: .summary.error
+              skip: .summary.skip
+              createdAt: .metadata.creationTimestamp


### PR DESCRIPTION
# Description

What - Added template assets (blueprints.json and config.yaml) files to bring reports and policies to Port
Why - Customers don't have the ability to import their Kyverno cluster policies and reports to Port using the K8s exporter
How - Used Kyverno's Policy, ClusterPolicy, PolicyReport and CluserPolicyReport [CRDs](https://kyverno.io/docs/introduction/) to ingest all namespace scoped and cluster scoped kyverno data to Port

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

