### PR TITLE
Add AWS AutoScaling Group resources to AWS Exporter

### DIFF
--- a/aws/autoscaling_group/blueprint.tf
+++ b/aws/autoscaling_group/blueprint.tf
@@ -1,0 +1,71 @@
+terraform {
+  required_providers {
+    port-labs = {
+      source  = "port-labs/port-labs"
+      version = "0.10.4"
+    }
+  }
+}
+
+resource "port-labs_blueprint" "autoscaling_group" {
+  title      = "Auto Scaling Group"
+  icon       = "AWS"
+  identifier = "awsAutoScalingGroup"
+
+  properties {
+    identifier = "desiredCapacity"
+    type       = "number"
+    title      = "Desired Capacity"
+  }
+
+  properties {
+    identifier = "minimumCapacity"
+    type       = "number"
+    title      = "Minimum Capacity"
+  }
+
+  properties {
+    identifier = "maximumCapacity"
+    type       = "number"
+    title      = "Maximum Capacity"
+  }
+
+  properties {
+    identifier = "availabilityZones"
+    type       = "array"
+    title      = "Availability Zones"
+  }
+
+  properties {
+    identifier = "healthCheckType"
+    type       = "string"
+    title      = "Health Check Type"
+  }
+
+  properties {
+    identifier = "serviceRoleArn"
+    type       = "string"
+    title      = "Service Role ARN"
+  }
+
+  properties {
+    identifier = "loadBalancerNames"
+    type       = "array"
+    title      = "Load Balancer Names"
+  }
+
+  properties {
+    identifier = "tags"
+    type       = "array"
+    title      = "Tags"
+  }
+  
+  relations {
+      target     = "region"
+      title      = "Region"
+      identifier = "region"
+      many       = false
+      required   = false
+    }
+
+}

--- a/aws/autoscaling_group/config.json
+++ b/aws/autoscaling_group/config.json
@@ -1,0 +1,24 @@
+{
+    "kind": "AWS::AutoScaling::AutoScalingGroup",
+    "port": {
+      "entity": {
+        "mappings": [
+          {
+            "identifier": ".AutoScalingGroupName",
+            "title": ".AutoScalingGroupName",
+            "blueprint": "awsAutoScalingGroup",
+            "properties": {
+              "desiredCapacity": ".DesiredCapacity",
+              "minimumCapacity": ".MinSize",
+              "maximumCapacity": ".MaxSize",
+              "availabilityZones": ".AvailabilityZones",
+              "loadBalancerNames": ".LoadBalancerNames",
+              "healthCheckType": ".HealthCheckType",
+              "serviceRoleArn": ".ServiceLinkedRoleARN",
+              "tags": ".Tags"
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/aws/autoscaling_group/event_rule.yaml
+++ b/aws/autoscaling_group/event_rule.yaml
@@ -1,0 +1,69 @@
+AutoScalingGroupEventRule:
+  Type: AWS::Events::Rule
+  Properties:
+    EventBusName: default
+    EventPattern:
+      detail-type:
+        - AWS API Call via CloudTrail
+      source:
+        - aws.autoscaling
+      detail:
+        eventSource:
+          - autoscaling.amazonaws.com
+        eventName:
+          - prefix: CreateAutoScalingGroup
+          - prefix: DeleteAutoScalingGroup
+          - prefix: UpdateAutoScalingGroup
+    Name: port-aws-exporter-sync-auto-scaling-group-trails
+    State: ENABLED
+    Targets:
+      - Id: PortAWSExporterEventsQueue
+        Arn:
+          Fn::ImportValue:
+            Fn::Sub: ${PortAWSExporterStackName}-EventsQueueARN
+        InputTransformer:
+          InputPathsMap:
+            awsRegion: $.detail.awsRegion
+            eventName: $.detail.eventName
+            autoScalingGroupName: $.detail.requestParameters.autoScalingGroupName
+          InputTemplate: >-
+            {
+              "resource_type": "AWS::AutoScaling::AutoScalingGroup",
+              "region": "\"<awsRegion>\"",
+              "identifier": "\"<autoScalingGroupName>\"",
+              "action": "if \"<eventName>\" | startswith(\"DeleteAutoScalingGroup\") then \"delete\" else \"upsert\" end"
+            }
+AutoScalingGroupTagRule:
+  Type: AWS::Events::Rule
+  Properties:
+    EventBusName: default
+    EventPattern:
+      source:
+        - aws.autoscaling
+      detail-type:
+        - AWS API Call via CloudTrail
+      detail:
+        eventSource:
+          - autoscaling.amazonaws.com
+        eventName:
+          - prefix: CreateOrUpdateTags
+          - prefix: DeleteTags
+    Name: port-aws-exporter-sync-auto-scaling-group-tags-trails
+    State: ENABLED
+    Targets:
+      - Id: PortAWSExporterEventsQueue
+        Arn:
+          Fn::ImportValue:
+            Fn::Sub: ${PortAWSExporterStackName}-EventsQueueARN
+        InputTransformer:
+          InputPathsMap:
+            awsRegion: $.detail.awsRegion
+            eventName: $.detail.eventName
+            resourceId: $.detail.requestParameters.tags[0].resourceId
+          InputTemplate: |-
+            {
+              "resource_type": "AWS::AutoScaling::AutoScalingGroup",
+              "region": "\"<awsRegion>\"",
+              "identifier": "\"<resourceId>\"",
+              "action": "\"upsert\""
+            }

--- a/aws/autoscaling_group/policy.json
+++ b/aws/autoscaling_group/policy.json
@@ -1,0 +1,3 @@
+[
+    "autoscaling:Describe*"
+]

--- a/aws/aws_blueprints_template/main.tf
+++ b/aws/aws_blueprints_template/main.tf
@@ -105,3 +105,9 @@ module "port_ecr_repository" {
   count = contains(var.resources, "ecr_repository") ? 1 : 0
   depends_on = [port-labs_blueprint.region]
 }
+
+module "port_autoscaling_group" {
+  source = "../autoscaling_group"
+  count = contains(var.resources, "autoscaling_group") ? 1 : 0
+  depends_on = [port-labs_blueprint.region]
+}


### PR DESCRIPTION
# Description

What - Added configuration resources (blueprint, config, policy and event rule) for Auto Scaling Group to AWS Exporter template assets
Why - The exporter currently does not support AWS ASG
How - Used the cloudcontrol API to map resources properties from AWS and configured cloudtrail to listen to realtime events

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


