### PR TITLE
Add Fluxcd template assets

### DIFF
--- a/kubernetes/blueprints/fluxcd-blueprints.json
+++ b/kubernetes/blueprints/fluxcd-blueprints.json
@@ -1,0 +1,499 @@
+[
+    {
+      "identifier": "cluster",
+      "description": "This blueprint represents a Kubernetes Cluster",
+      "title": "Cluster",
+      "icon": "Cluster",
+      "schema": {
+        "properties": {},
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {}
+    },
+    {
+      "identifier": "namespace",
+      "description": "This blueprint represents a k8s Namespace",
+      "title": "Namespace",
+      "icon": "Environment",
+      "schema": {
+        "properties": {
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Namespace was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Namespace"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "Cluster": {
+          "title": "Cluster",
+          "description": "The namespace's Kubernetes cluster",
+          "target": "cluster",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "node",
+      "description": "This blueprint represents a k8s Node",
+      "title": "Node",
+      "icon": "Node",
+      "schema": {
+        "properties": {
+          "creationTimestamp": {
+            "type": "string",
+            "icon": "DeployedAt",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Node was created (added to the cluster)"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Node"
+          },
+          "ready": {
+            "type": "string",
+            "title": "Node Readiness",
+            "description": "Node ready status",
+            "enum": [
+              "True",
+              "False"
+            ],
+            "enumColors": {
+              "False": "red",
+              "True": "green"
+            }
+          },
+          "totalMemory": {
+            "type": "string",
+            "icon": "GPU",
+            "title": "Total Memory (kibibytes)",
+            "description": "Total memory capacity of the Node"
+          },
+          "kubeletVersion": {
+            "type": "string",
+            "title": "Kubelet Version",
+            "description": "The node's kubelet version"
+          },
+          "totalCPU": {
+            "type": "string",
+            "icon": "CPU",
+            "title": "Total CPU (milli-cores)",
+            "description": "Total CPU capacity of the Node"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "Cluster": {
+          "title": "Cluster",
+          "target": "cluster",
+          "required": false,
+          "many": true
+        }
+      }
+    },
+    {
+      "identifier": "workload",
+      "description": "This blueprint represents a k8s Workload. This includes all k8s objects which can create pods (deployments[replicasets], daemonsets, statefulsets...)",
+      "title": "Workload",
+      "icon": "Deployment",
+      "schema": {
+        "properties": {
+          "availableReplicas": {
+            "type": "number",
+            "title": "Running Replicas",
+            "description": "Current running replica count"
+          },
+          "containers": {
+            "type": "array",
+            "title": "Containers",
+            "default": [],
+            "description": "The containers for each pod instance of the Workload"
+          },
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Workload was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Workload"
+          },
+          "replicas": {
+            "type": "number",
+            "title": "Wanted Replicas",
+            "description": "Wanted replica count"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "description": "Rollout Strategy"
+          },
+          "hasPrivileged": {
+            "type": "boolean",
+            "title": "Has Privileged Container"
+          },
+          "hasLatest": {
+            "type": "boolean",
+            "title": "Has 'latest' tag",
+            "description": "Has Container with 'latest' as image tag"
+          },
+          "hasLimits": {
+            "type": "boolean",
+            "title": "All containers have limits"
+          },
+          "isHealthy": {
+            "type": "string",
+            "enum": [
+              "Healthy",
+              "Unhealthy"
+            ],
+            "enumColors": {
+              "Healthy": "green",
+              "Unhealthy": "red"
+            },
+            "title": "Workload Health"
+          },
+          "kind": {
+            "title": "Workload Kind",
+            "description": "The kind of Workload",
+            "type": "string",
+            "enum": [
+              "StatefulSet",
+              "DaemonSet",
+              "Deployment",
+              "Rollout"
+            ]
+          },
+          "strategyConfig": {
+            "type": "object",
+            "title": "Strategy Config",
+            "description": "The workloads rollout strategy"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "namespace": {
+          "title": "Namespace",
+          "target": "namespace",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "replicaSet",
+      "description": "This blueprint represents a k8s ReplicaSet",
+      "title": "ReplicaSet",
+      "icon": "Deployment",
+      "schema": {
+        "properties": {
+          "replicaSetJson": {
+            "title": "ReplicaSet Json",
+            "type": "object",
+            "description": "The ReplicaSet json"
+          },
+          "availableReplicas": {
+            "type": "number",
+            "title": "Running Replicas",
+            "description": "Current running replica count"
+          },
+          "containers": {
+            "type": "array",
+            "title": "Containers",
+            "default": [],
+            "description": "The containers for each pod instance of the Workload"
+          },
+          "creationTimestamp": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "When the Workload was created"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Workload"
+          },
+          "replicas": {
+            "type": "number",
+            "title": "Wanted Replicas",
+            "description": "Wanted replica count"
+          },
+          "strategy": {
+            "type": "string",
+            "title": "Strategy",
+            "description": "Rollout Strategy"
+          },
+          "hasPrivileged": {
+            "type": "boolean",
+            "title": "Has Privileged Container"
+          },
+          "hasLatest": {
+            "type": "boolean",
+            "title": "Has 'latest' tag",
+            "description": "Has Container with 'latest' as image tag"
+          },
+          "hasLimits": {
+            "type": "boolean",
+            "title": "All containers have limits"
+          },
+          "isHealthy": {
+            "type": "string",
+            "enum": [
+              "Healthy",
+              "Unhealthy"
+            ],
+            "enumColors": {
+              "Healthy": "green",
+              "Unhealthy": "red"
+            },
+            "title": "ReplicaSet Health"
+          },
+          "strategyConfig": {
+            "type": "object",
+            "title": "Strategy Config",
+            "description": "The ReplicaSet rollout strategy"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {},
+      "calculationProperties": {},
+      "relations": {
+        "replicaSetManager": {
+          "title": "Manager",
+          "target": "workload",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+      "identifier": "pod",
+      "description": "This blueprint represents a k8s Pod",
+      "title": "Pod",
+      "icon": "Service",
+      "schema": {
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "title": "Conditions",
+            "default": [],
+            "description": "Pod's conditions"
+          },
+          "labels": {
+            "type": "object",
+            "title": "Labels",
+            "description": "Labels of the Pod"
+          },
+          "phase": {
+            "type": "string",
+            "title": "Pod phase",
+            "description": "Pod's running phase"
+          },
+          "startTime": {
+            "type": "string",
+            "title": "Created",
+            "format": "date-time",
+            "description": "Pod's creation date"
+          }
+        },
+        "required": []
+      },
+      "mirrorProperties": {
+        "containers": {
+          "title": "Containers",
+          "path": "workload.containers"
+        }
+      },
+      "calculationProperties": {},
+      "relations": {
+        "Node": {
+          "title": "Node",
+          "description": "The node the pod is running on",
+          "target": "node",
+          "required": false,
+          "many": false
+        },
+        "workload": {
+          "title": "Workload",
+          "description": "The workload responsible for the pod",
+          "target": "workload",
+          "required": false,
+          "many": false
+        },
+        "replicaSet": {
+          "title": "ReplicaSet",
+          "description": "The ReplicaSet managing the pod (if it exists)",
+          "target": "replicaSet",
+          "required": false,
+          "many": false
+        }
+      }
+    },
+    {
+        "identifier": "fluxSource",
+        "description": "Flux Source",
+        "title": "Flux Source",
+        "icon": "Fluxcd",
+        "schema": {
+          "properties": {
+            "repoURL": {
+              "type": "string",
+              "icon": "Git",
+              "title": "Repository URL",
+              "description": "The URL of the repository containing the application source code"
+            },
+            "sourceType": {
+              "icon": "DefaultProperty",
+              "title": "Source Type",
+              "description": "The flux source type",
+              "type": "string",
+              "enum": [
+                "HelmRepository",
+                "GitRepository"
+              ],
+              "enumColors": {
+                "HelmRepository": "turquoise",
+                "GitRepository": "green"
+              }
+            },
+            "interval": {
+              "icon": "Clock",
+              "type": "string",
+              "title": "Interval",
+              "description": "Interval at which the GitRepository URL is checked for updates"
+            },
+            "createdAt": {
+              "title": "Created At",
+              "type": "string",
+              "format": "date-time",
+              "icon": "DefaultProperty"
+            },
+            "branch": {
+              "title": "Branch",
+              "type": "string",
+              "icon": "DefaultProperty"
+            }
+          },
+          "required": []
+        },
+        "mirrorProperties": {},
+        "calculationProperties": {},
+        "aggregationProperties": {},
+        "relations": {
+          "namespace": {
+            "title": "Namespace",
+            "target": "namespace",
+            "required": false,
+            "many": false
+          }
+        }
+      },
+      {
+        "identifier": "fluxApplication",
+        "description": "This blueprint represents Flux Application which can be HelmRelease or Kustomization",
+        "title": "Flux Application",
+        "icon": "Fluxcd",
+        "schema": {
+          "properties": {
+            "targetNamespace": {
+              "icon": "DefaultProperty",
+              "type": "string",
+              "title": "Target Namespace"
+            },
+            "namespace": {
+              "type": "string",
+              "title": "Namespace",
+              "icon": "DefaultProperty"
+            },
+            "ready": {
+              "icon": "DefaultProperty",
+              "title": "Health Status",
+              "description": "The health status of the application",
+              "type": "string",
+              "enum": [
+                "True",
+                "False",
+                "Unknown"
+              ],
+              "enumColors": {
+                "True": "green",
+                "False": "red",
+                "Unknown": "lightGray"
+              }
+            },
+            "createdAt": {
+              "title": "Created At",
+              "type": "string",
+              "format": "date-time",
+              "icon": "DefaultProperty"
+            },
+            "applicationType": {
+              "icon": "DefaultProperty",
+              "title": "Application Type",
+              "description": "Kustomization or HelmRelease",
+              "type": "string",
+              "enum": [
+                "HelmRelease",
+                "Kustomization"
+              ],
+              "enumColors": {
+                "HelmRelease": "lightGray",
+                "Kustomization": "lightGray"
+              }
+            },
+            "interval": {
+              "icon": "Clock",
+              "type": "string",
+              "title": "Interval",
+              "description": "The interval at which the application will be reconciled"
+            },
+            "path": {
+              "title": "Path",
+              "type": "string",
+              "icon": "DefaultProperty"
+            },
+            "prune": {
+              "title": "Prune",
+              "type": "boolean",
+              "icon": "DefaultProperty"
+            }
+          },
+          "required": []
+        },
+        "mirrorProperties": {},
+        "calculationProperties": {},
+        "aggregationProperties": {},
+        "relations": {
+          "source": {
+            "title": "Source",
+            "target": "fluxSource",
+            "required": false,
+            "many": false
+          }
+        }
+      }
+  ]

--- a/kubernetes/blueprints/fluxcd-blueprints.json
+++ b/kubernetes/blueprints/fluxcd-blueprints.json
@@ -442,7 +442,7 @@
               "enumColors": {
                 "True": "green",
                 "False": "red",
-                "Unknown": "lightGray"
+                "Unknown": "yellow"
               }
             },
             "createdAt": {

--- a/kubernetes/fluxcd_config.tmpl
+++ b/kubernetes/fluxcd_config.tmpl
@@ -1,0 +1,73 @@
+  - kind: source.toolkit.fluxcd.io/v1/gitrepositories
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Fluxcd"'
+            blueprint: '"fluxSource"'
+            properties:
+              repoURL: .spec.url
+              sourceType: .kind
+              branch: .spec.ref.branch
+              interval: .spec.interval
+              createdAt: .metadata.creationTimestamp
+            relations:
+              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+
+  - kind: source.toolkit.fluxcd.io/v1beta2/helmrepositories
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Fluxcd"'
+            blueprint: '"fluxSource"'
+            properties:
+              repoURL: .spec.url
+              sourceType: .kind
+              branch: .spec.ref.branch
+              interval: .spec.interval
+              createdAt: .metadata.creationTimestamp
+            relations:
+              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+
+  - kind: kustomize.toolkit.fluxcd.io/v1/kustomizations
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Fluxcd"'
+            blueprint: '"fluxApplication"'
+            properties:
+              targetNamespace: .spec.targetNamespace
+              namespace: .metadata.namespace
+              ready: .status.conditions[] | select(.type == "Ready") | .status
+              path: .spec.path
+              prune: .spec.prune
+              applicationType: .kind
+              interval: .spec.interval
+              createdAt: .metadata.creationTimestamp
+            relations:
+              source: .spec.sourceRef.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+  
+  - kind: helm.toolkit.fluxcd.io/v2beta2/helmreleases
+    port:
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .metadata.name
+            icon: '"Fluxcd"'
+            blueprint: '"fluxApplication"'
+            properties:
+              targetNamespace: .spec.targetNamespace
+              namespace: .metadata.namespace
+              ready: .status.conditions[] | select(.type == "Ready") | .status
+              path: .spec.path
+              prune: .spec.prune
+              applicationType: .kind
+              interval: .spec.chart.spec.interval
+              createdAt: .metadata.creationTimestamp
+            relations:
+              source: .spec.chart.spec.sourceRef.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME

--- a/kubernetes/template_list.json
+++ b/kubernetes/template_list.json
@@ -24,5 +24,10 @@
         "name": "Trivy",
         "description": "Contains Trivy resources",
         "path": "trivy_config.tmpl"
+    },
+    "fluxcd": {
+        "name": "FluxCD",
+        "description": "Contains FluxCD resources",
+        "path": "fluxcd_config.tmpl"
     }
 }


### PR DESCRIPTION
# Description
Added FluxCD template assets (blueprints and config.json) to the K8s exporter

What - Added FluxCD template assets (blueprints and config.json) to the K8s exporter
Why - Customer requested for support for FluxCD
How - Used our K8s exporter to map FluxCD sources (GitRepositories & HelmRepositories) and FluxCD applications (Kustomization and HelmRelease) to Port

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

