### PR TITLE
removed status.conditions from v1/pods in all examples

### DIFF
--- a/kubernetes/blueprints/argo-argo_rollouts-blueprints.json
+++ b/kubernetes/blueprints/argo-argo_rollouts-blueprints.json
@@ -227,12 +227,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/argo-blueprints.json
+++ b/kubernetes/blueprints/argo-blueprints.json
@@ -226,12 +226,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/fluxcd-blueprints.json
+++ b/kubernetes/blueprints/fluxcd-blueprints.json
@@ -298,12 +298,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/istio-blueprints.json
+++ b/kubernetes/blueprints/istio-blueprints.json
@@ -226,12 +226,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/kubernetes_complete_usecase_bps.json
+++ b/kubernetes/blueprints/kubernetes_complete_usecase_bps.json
@@ -314,12 +314,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/kubernetes_knative_usecase.json
+++ b/kubernetes/blueprints/kubernetes_knative_usecase.json
@@ -479,12 +479,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/kyverno-blueprints.json
+++ b/kubernetes/blueprints/kyverno-blueprints.json
@@ -298,12 +298,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/opencosts_bps.json
+++ b/kubernetes/blueprints/opencosts_bps.json
@@ -314,12 +314,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/openshift-blueprints.json
+++ b/kubernetes/blueprints/openshift-blueprints.json
@@ -298,12 +298,6 @@
     "icon": "Service",
     "schema": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "title": "Conditions",
-          "default": [],
-          "description": "Pod's conditions"
-        },
         "labels": {
           "type": "object",
           "title": "Labels",

--- a/kubernetes/blueprints/trivy-blueprints.json
+++ b/kubernetes/blueprints/trivy-blueprints.json
@@ -226,12 +226,6 @@
         "icon": "Service",
         "schema": {
             "properties": {
-                "conditions": {
-                    "type": "array",
-                    "title": "Conditions",
-                    "default": [],
-                    "description": "Pod's conditions"
-                },
                 "labels": {
                     "type": "object",
                     "title": "Labels",

--- a/kubernetes/full-configs/kubernetes_kantive_usecase.yaml
+++ b/kubernetes/full-configs/kubernetes_kantive_usecase.yaml
@@ -143,7 +143,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/full-configs/openshift_usecase.yaml
+++ b/kubernetes/full-configs/openshift_usecase.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/kubernetes_config.yaml
+++ b/kubernetes/kubernetes_config.yaml
@@ -116,7 +116,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: '(.metadata.ownerReferences[0].name | split("-") | .[:-1] | join("-")) + "-" + "Deployment" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME'
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
@@ -137,7 +136,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/kubernetes_v1_config.yaml
+++ b/kubernetes/kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-fluxcd-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-fluxcd-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-argo_rollouts-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-argo_rollouts-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-fluxcd-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-fluxcd-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/argo-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/argo-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/fluxcd-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/fluxcd-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/istio-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/istio-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/istio-kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/istio-kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/istio-kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/istio-kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/istio-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/istio-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/kubernetes_v1_config.yaml
+++ b/kubernetes/templates/kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/kyverno-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/kyverno-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/kyverno-trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/kyverno-trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME

--- a/kubernetes/templates/trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/trivy-kubernetes_v1_config.yaml
@@ -140,7 +140,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               replicaSet: .metadata.ownerReferences[0].name + "-" + "ReplicaSet" + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME // ""
@@ -162,7 +161,6 @@ resources: # List of K8s resources to list, watch, and export to Port.
               phase: .status.phase
               labels: .metadata.labels
               containers: (.spec.containers | map({image, resources})) + .status.containerStatuses | group_by(.image) | map(add)
-              conditions: .status.conditions
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME


### PR DESCRIPTION
# Description

What - removed status.conditions from v1/pods in all examples
Why - changes in status.conditions trigger too many updates to the resources
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

