### PR TITLE
[K8S Exporter] - Update Trivy audit report config mapping

### DIFF
--- a/kubernetes/blueprints/trivy-blueprints.json
+++ b/kubernetes/blueprints/trivy-blueprints.json
@@ -378,79 +378,176 @@
       }
   },
   {
-      "identifier": "trivyVulnerabilities",
-      "title": "Trivy Vulnerabilities",
-      "icon": "Trivy",
-      "schema": {
-          "properties": {
-              "scanner": {
-                  "title": "Scanner",
-                  "type": "string"
-              },
-              "criticalCount": {
-                  "title": "Critical Count",
-                  "type": "number"
-              },
-              "highCount": {
-                  "title": "High Count",
-                  "type": "number"
-              },
-              "lowCount": {
-                  "title": "Low Count",
-                  "type": "number"
-              },
-              "mediumCount": {
-                  "title": "Medium Count",
-                  "type": "number"
-              },
-              "category": {
-                  "title": "Category",
-                  "type": "string"
-              },
-              "message": {
-                  "title": "Message",
-                  "type": "array"
-              },
-              "severity": {
-                  "title": "Severity",
-                  "type": "string",
-                  "enum": [
-                      "LOW",
-                      "MEDIUM",
-                      "HIGH",
-                      "CRITICAL",
-                      "UNKNOWN"
-                  ],
-                  "enumColors": {
-                      "LOW": "green",
-                      "MEDIUM": "yellow",
-                      "HIGH": "red",
-                      "CRITICAL": "red",
-                      "UNKNOWN": "lightGray"
-                  }
-              },
-              "scannerVersion": {
-                  "title": "Scanner Version",
-                  "type": "string"
-              },
-              "createdAt": {
-                  "title": "Created At",
-                  "type": "string",
-                  "format": "date-time"
-              }
-          },
-          "required": []
-      },
-      "mirrorProperties": {},
-      "calculationProperties": {},
-      "aggregationProperties": {},
-      "relations": {
-          "namespace": {
-              "title": "Namespace",
-              "target": "namespace",
-              "required": false,
-              "many": false
+    "identifier": "trivyConfigAuditReport",
+    "title": "Trivy Config Audit Report",
+    "icon": "Trivy",
+    "schema": {
+      "properties": {
+        "category": {
+          "title": "Category",
+          "type": "string"
+        },
+        "messages": {
+          "title": "Messages",
+          "type": "array"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "severity": {
+          "title": "Severity",
+          "type": "string",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH",
+            "CRITICAL",
+            "UNKNOWN"
+          ],
+          "enumColors": {
+            "LOW": "green",
+            "MEDIUM": "yellow",
+            "HIGH": "red",
+            "CRITICAL": "red",
+            "UNKNOWN": "lightGray"
           }
+        },
+        "remediation": {
+          "title": "Remediation",
+          "type": "string"
+        },
+        "success": {
+          "title": "Success",
+          "type": "boolean"
+        },
+        "scanner": {
+          "title": "Scanner",
+          "type": "string"
+        },
+        "scannerVersion": {
+          "title": "Scanner Version",
+          "type": "string"
+        },
+        "createdAt": {
+          "title": "Created At",
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "title": "Updated At",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {
+      "namespace": {
+        "title": "Namespace",
+        "target": "namespace",
+        "required": false,
+        "many": false
       }
+    }
+  },
+  {
+    "identifier": "trivyVulnerabilityReport",
+    "title": "Trivy Vulnerability Report",
+    "icon": "Trivy",
+    "schema": {
+      "properties": {
+        "resource": {
+          "title": "Resource",
+          "type": "string"
+        },
+        "score": {
+          "title": "Score",
+          "type": "number"
+        },
+        "fixedVersion": {
+          "title": "Fixed Version",
+          "type": "string"
+        },
+        "installedVersion": {
+          "title": "Installed Version",
+          "type": "string"
+        },
+        "lastModifiedDate": {
+          "title": "Last Modified Date",
+          "type": "string",
+          "format": "date-time"
+        },
+        "links": {
+          "icon": "DefaultProperty",
+          "title": "Links",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "url"
+          }
+        },
+        "primaryLink": {
+          "title": "Primary Link",
+          "type": "string",
+          "format": "url"
+        },
+        "publishedDate": {
+          "title": "Published Date",
+          "type": "string",
+          "format": "date-time"
+        },
+        "severity": {
+          "title": "Severity",
+          "type": "string",
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH",
+            "CRITICAL",
+            "UNKNOWN"
+          ],
+          "enumColors": {
+            "LOW": "green",
+            "MEDIUM": "yellow",
+            "HIGH": "red",
+            "CRITICAL": "red",
+            "UNKNOWN": "lightGray"
+          }
+        },
+        "target": {
+          "title": "Target",
+          "type": "string"
+        },
+        "scanner": {
+          "title": "Scanner Name",
+          "type": "string"
+        },
+        "scannerVersion": {
+          "title": "Scanner Version",
+          "type": "string"
+        },
+        "createdAt": {
+          "title": "Created At",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {
+      "namespace": {
+        "title": "Namespace",
+        "target": "namespace",
+        "required": false,
+        "many": false
+      }
+    }
   }
 ]

--- a/kubernetes/trivy_config.tmpl
+++ b/kubernetes/trivy_config.tmpl
@@ -1,20 +1,51 @@
   - kind: aquasecurity.github.io/v1alpha1/configauditreports
+    selector:
+      query: 'true'
     port:
+      itemsToParse: .report.checks
       entity:
         mappings:
-          - identifier: .metadata.name + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
-            title: .metadata.name
+          - identifier: .metadata.name + "-" + .item.checkID + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .item.title
             icon: '"Trivy"'
-            blueprint: '"trivyVulnerabilities"'
+            blueprint: '"trivyConfigAuditReport"'
             properties:
+              category: .item.category
+              messages: .item.messages
+              description: .item.description
+              severity: .item.severity
+              remediation: .item.remediation
+              success: .item.success
               scanner: .report.scanner.name
-              criticalCount: .report.summary.criticalCount
-              highCount: .report.summary.highCount
-              lowCount: .report.summary.lowCount
-              mediumCount: .report.summary.mediumCount
-              category: .report.checks[0].category
-              message: .report.checks[0].messages
-              severity: .report.checks[0].severity
+              scannerVersion: .report.scanner.version
+              createdAt: .metadata.creationTimestamp
+              updatedAt: .report.updateTimestamp
+            relations:
+              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+
+  - kind: aquasecurity.github.io/v1alpha1/vulnerabilityreports
+    selector:
+      query: 'true'
+    port:
+      itemsToParse: .report.vulnerabilities
+      entity:
+        mappings:
+          - identifier: .metadata.name + "-" + .item.vulnerabilityID + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+            title: .item.title
+            icon: '"Trivy"'
+            blueprint: '"trivyVulnerabilityReport"'
+            properties:
+              resource: .item.resource
+              score: .item.score
+              fixedVersion: .item.fixedVersion
+              installedVersion: .item.installedVersion
+              lastModifiedDate: .item.lastModifiedDate
+              links: .item.links
+              primaryLink: .item.primaryLink
+              publishedDate: .item.publishedDate
+              severity: .item.severity
+              target: .item.target
+              scanner: .report.scanner.name
               scannerVersion: .report.scanner.version
               createdAt: .metadata.creationTimestamp
             relations:


### PR DESCRIPTION
# Description

Improved on the Trivy k8s exporter by using `itemsToParse` to bring all Trivy resources. In the previous release, we could only bring the top level audit configuration checks for a trivy scan. now thanks to `itemsToParse`, we can expand the .report.checks array and ingest all data to port. Also added vulnerability reports to the exporter. 

What -
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

![image](https://github.com/port-labs/template-assets/assets/15999660/234c8e2f-8fc7-4d21-b24c-8f4caaa39b01)

![image](https://github.com/port-labs/template-assets/assets/15999660/628c5c11-af38-4800-a9ab-3afb388caa50)
