### PR TITLE
feat: allow to call aws as a terraform module

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.1.0"
+    }
     local = {
       source = "hashicorp/local"
       version = "2.4.0"

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -29,7 +29,7 @@ locals {
   combined_config = <<EOF
  {
    "resources": [
-     ${join(",", [for resource in var.resources : file("./${resource}/config.json")])}
+     ${join(",", [for resource in var.resources : file("${path.module}/${resource}/config.json")])}
    ]
  }
  EOF
@@ -47,7 +47,7 @@ Parameters:
     AllowedPattern: ^[a-zA-Z][-a-zA-Z0-9]*$
     Default: serverlessrepo-port-aws-exporter
 Resources:
-${join("\n", [for resource in var.resources : "  ${indent(2, file("./${resource}/event_rule.yaml"))}"])}
+${join("\n", [for resource in var.resources : "  ${indent(2, file("${path.module}/${resource}/event_rule.yaml"))}"])}
   EOF
 
   # Generates the Lambda policy json
@@ -57,7 +57,7 @@ ${join("\n", [for resource in var.resources : "  ${indent(2, file("./${resource}
  "Statement": [
    {
      "Effect": "Allow",
-     "Action": ${jsonencode(flatten([for resource in var.resources : jsondecode(file("./${resource}/policy.json"))]))},
+     "Action": ${jsonencode(flatten([for resource in var.resources : jsondecode(file("${path.module}/${resource}/policy.json"))]))},
      "Resource": "*"
    }
  ]


### PR DESCRIPTION
# Description

To better integrate with enterprises IaC strategy, it makes sense to allow calling this template as a terraform/opentofu module.

This PR makes minor changes that will allow to read files from the module root rather than the main root.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

