### PR TITLE
PORT-8430 Update the trivy blueprints and mapping

### DIFF
--- a/kubernetes/blueprints/trivy-blueprints.json
+++ b/kubernetes/blueprints/trivy-blueprints.json
@@ -441,12 +441,12 @@
         "calculationProperties": {},
         "aggregationProperties": {},
         "relations": {
-          "namespace": {
-            "title": "Namespace",
-            "target": "namespace",
-            "required": false,
-            "many": false
-          }
+            "kubernetes_resource": {
+                "title": "Kubernetes Resource",
+                "target": "workload",
+                "required": false,
+                "many": false
+            }
         }
       },
       {
@@ -537,12 +537,12 @@
         "calculationProperties": {},
         "aggregationProperties": {},
         "relations": {
-          "namespace": {
-            "title": "Namespace",
-            "target": "namespace",
-            "required": false,
-            "many": false
-          }
+            "kubernetes_resource": {
+              "title": "Kubernetes Resource",
+              "target": "workload",
+              "required": false,
+              "many": false
+            }
         }
       }
 ]

--- a/kubernetes/templates/trivy-kubernetes_v1_config.yaml
+++ b/kubernetes/templates/trivy-kubernetes_v1_config.yaml
@@ -206,7 +206,15 @@ resources: # List of K8s resources to list, watch, and export to Port.
               createdAt: .metadata.creationTimestamp
               updatedAt: .report.updateTimestamp
             relations:
-              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+              kubernetes_resource: (
+                if (.metadata.ownerReferences | length > 0) then 
+                     (.metadata.ownerReferences[] | select(.controller == true) |
+                     .name + "-" + .kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+                     )
+                  else
+                     empty
+                  end
+                )
 
   - kind: aquasecurity.github.io/v1alpha1/vulnerabilityreports
     selector:
@@ -234,4 +242,12 @@ resources: # List of K8s resources to list, watch, and export to Port.
               scannerVersion: .report.scanner.version
               createdAt: .metadata.creationTimestamp
             relations:
-              namespace: .metadata.namespace + "-" + env.CLUSTER_NAME
+              kubernetes_resource: (
+                if (.metadata.ownerReferences | length > 0) then 
+                     (.metadata.ownerReferences[] | select(.controller == true) |
+                     .name + "-" + .kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
+                     )
+                  else
+                     empty
+                  end
+                )


### PR DESCRIPTION
# Description
<img width="1560" alt="k8sTrivyOperatorView" src="https://github.com/port-labs/template-assets/assets/8656262/b8866abf-5261-4573-9891-279397973d7f">

This PR updates the Trivy config audit and vulnerability report blueprints and mapping, along with the [corresponding](https://github.com/port-labs/port-docs/pull/1263) documentation page.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

