### PR TITLE
Add selector object to k8s config

### DIFF
--- a/kubernetes/kubernetes_config.yaml
+++ b/kubernetes/kubernetes_config.yaml
@@ -26,6 +26,26 @@ resources: # List of K8s resources to list, watch, and export to Port.
             title: env.CLUSTER_NAME
             blueprint: '"cluster"'
 
+  - kind: v1/nodes
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          - identifier: (.metadata.name) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
+            title: .metadata.name + "-" + env.CLUSTER_NAME
+            icon: '"Node"'
+            blueprint: '"node"'
+            properties:
+              creationTimestamp: .metadata.creationTimestamp
+              totalCPU: .status.allocatable.cpu
+              totalMemory: .status.allocatable.memory
+              labels: .metadata.labels
+              kubeletVersion: .status.nodeInfo.kubeletVersion | split("-") | .[0]
+              ready: .status.conditions[] | select(.type == "Ready") | .status
+            relations:
+              Cluster: env.CLUSTER_NAME
+
   - kind: apps/v1/deployments
     selector:
       query: .metadata.namespace | startswith("kube") | not
@@ -139,21 +159,4 @@ resources: # List of K8s resources to list, watch, and export to Port.
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
-              
-  - kind: v1/nodes
-    port:
-      entity:
-        mappings:
-          - identifier: (.metadata.name) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
-            title: .metadata.name + "-" + env.CLUSTER_NAME
-            icon: '"Node"'
-            blueprint: '"node"'
-            properties:
-              creationTimestamp: .metadata.creationTimestamp
-              totalCPU: .status.allocatable.cpu
-              totalMemory: .status.allocatable.memory
-              labels: .metadata.labels
-              kubeletVersion: .status.nodeInfo.kubeletVersion | split("-") | .[0]
-              ready: .status.conditions[] | select(.type == "Ready") | .status
-            relations:
-              Cluster: env.CLUSTER_NAME
+

--- a/kubernetes/kubernetes_v1_config.yaml
+++ b/kubernetes/kubernetes_v1_config.yaml
@@ -26,6 +26,26 @@ resources: # List of K8s resources to list, watch, and export to Port.
             title: env.CLUSTER_NAME
             blueprint: '"cluster"'
 
+  - kind: v1/nodes
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          - identifier: (.metadata.name) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
+            title: .metadata.name + "-" + env.CLUSTER_NAME
+            icon: '"Node"'
+            blueprint: '"node"'
+            properties:
+              creationTimestamp: .metadata.creationTimestamp
+              totalCPU: .status.allocatable.cpu
+              totalMemory: .status.allocatable.memory
+              labels: .metadata.labels
+              kubeletVersion: .status.nodeInfo.kubeletVersion | split("-") | .[0]
+              ready: .status.conditions[] | select(.type == "Ready") | .status
+            relations:
+              Cluster: env.CLUSTER_NAME
+
   - kind: apps/v1/deployments
     selector:
       query: .metadata.namespace | startswith("kube") | not
@@ -164,21 +184,4 @@ resources: # List of K8s resources to list, watch, and export to Port.
             relations:
               workload: .metadata.ownerReferences[0].name + "-" + .metadata.ownerReferences[0].kind + "-" + .metadata.namespace + "-" + env.CLUSTER_NAME
               Node: (.spec.nodeName) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
-              
-  - kind: v1/nodes
-    port:
-      entity:
-        mappings:
-          - identifier: (.metadata.name) | (split(".")|join("_")) + "-" + env.CLUSTER_NAME
-            title: .metadata.name + "-" + env.CLUSTER_NAME
-            icon: '"Node"'
-            blueprint: '"node"'
-            properties:
-              creationTimestamp: .metadata.creationTimestamp
-              totalCPU: .status.allocatable.cpu
-              totalMemory: .status.allocatable.memory
-              labels: .metadata.labels
-              kubeletVersion: .status.nodeInfo.kubeletVersion | split("-") | .[0]
-              ready: .status.conditions[] | select(.type == "Ready") | .status
-            relations:
-              Cluster: env.CLUSTER_NAME
+


### PR DESCRIPTION
# Description

What - The configuration yaml for the k8s node mapping did not have the selector object. as a result, the nodes entities were not ingested, and this caused pods entities to not be ingested because of the relation.
Why -
How - Added the selector object with query: 'true' to the v1/nodes mapping

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

